### PR TITLE
etc/tools/ParaView4Functions: fixed MPI_LIBRARY and MPI_EXTRA_LIBRARY

### DIFF
--- a/etc/tools/ParaView4Functions
+++ b/etc/tools/ParaView4Functions
@@ -166,10 +166,10 @@ addMpiSupport()
 
     addCMakeVariable  "PARAVIEW_USE_MPI=ON VTK_USE_MPI=ON"
     addCMakeVariable  "MPI_INCLUDE_PATH=$MPI_ARCH_PATH/include"
-    addCMakeVariable  "MPI_LIBRARY=$MPI_ARCH_PATH/lib/libmpi.so"
-    if [ -e $MPI_ARCH_PATH/lib/libmpi_cxx.so ]
+    addCMakeVariable  "MPI_LIBRARY=$MPI_ARCH_PATH/lib${WM_COMPILER_LIB_ARCH}/libmpi.so"
+    if [ -e $MPI_ARCH_PATH/lib${WM_COMPILER_LIB_ARCH}/libmpi_cxx.so ]
     then
-        addCMakeVariable  "MPI_EXTRA_LIBRARY=$MPI_ARCH_PATH/lib/libmpi_cxx.so"
+        addCMakeVariable  "MPI_EXTRA_LIBRARY=$MPI_ARCH_PATH/lib${WM_COMPILER_LIB_ARCH}/libmpi_cxx.so"
     fi
     addCMakeVariable  "VTK_MPIRUN_EXE=$MPI_ARCH_PATH/bin/mpirun"
     addCMakeVariable  "VTK_MPI_MAX_NUMPROCS=$MPI_MAX_PROCS"


### PR DESCRIPTION
fixed MPI_LIBRARY and MPI_EXTRA_LIBRARY in etc/tools/ParaView4Functions for x86_64.
