### PR TITLE
modified makeCGAL to better handle the case where the user desires to use their own CGAL

### DIFF
--- a/makeCGAL
+++ b/makeCGAL
@@ -110,10 +110,15 @@ do
         mpfrPACKAGE="${1%%/}"
         shift
         ;;
-    CGAL-[0-9]*)
+    CGAL-[0-9]*) 
         cgalPACKAGE="${1%%/}"
         shift
         ;;
+    CGAL-sys* | cgal-sys*)
+	cgalPACKAGE="${1%%/}"
+	cgal_version="cgal-system"
+	shift
+	;;
     boost-[0-9]* | boost_[0-9]* | boost-sys* )
         boostPACKAGE="${1%%/}"
         shift


### PR DESCRIPTION
part of what was needed was already there, but was not complete. there was a check for `$cgal_version = cgal-system` but setting the cgal version to cgal-system would raise an error, as the argument parser did not recognize that as a valid option.